### PR TITLE
Add 'use client' directive to use-mobile hook

### DIFF
--- a/hooks/use-mobile.tsx
+++ b/hooks/use-mobile.tsx
@@ -1,3 +1,4 @@
+"use client"
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768


### PR DESCRIPTION
## Summary
- mark `use-mobile.tsx` as a client component for Next.js

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68721af551908326b3ec3e4a79b25895